### PR TITLE
Standardize vision config

### DIFF
--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -66,6 +66,23 @@ def get_settings():
         'azure_apim_image_gen_deployment': '',
         'azure_apim_image_gen_api_version': '',
 
+        # Vision (GPT-4o) Settings
+        'enable_vision_apim': False,
+        'azure_openai_vision_endpoint': '',
+        'azure_openai_vision_api_version': '2024-02-15-preview',
+        'azure_openai_vision_authentication_type': 'key',
+        'azure_openai_vision_subscription_id': '',
+        'azure_openai_vision_resource_group': '',
+        'azure_openai_vision_key': '',
+        'vision_model': {
+            "selected": [],
+            "all": []
+        },
+        'azure_apim_vision_endpoint': '',
+        'azure_apim_vision_subscription_key': '',
+        'azure_apim_vision_deployment': '',
+        'azure_apim_vision_api_version': '',
+
         # Workspaces
         'enable_user_workspace': True,
         'enable_group_workspaces': True,

--- a/application/single_app/functions_vision.py
+++ b/application/single_app/functions_vision.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 from typing import Union
 from openai import AzureOpenAI
 from PIL import Image
-import base64, io, os, functools
+import base64, io, functools
+
+from config import *
+from functions_settings import *
 
 def _b64(data: Union[bytes, Image.Image]) -> str:
     if isinstance(data, Image.Image):
@@ -18,10 +21,28 @@ def _b64(data: Union[bytes, Image.Image]) -> str:
 
 @functools.lru_cache
 def _client() -> AzureOpenAI:
+    settings = get_settings()
+    if settings.get("enable_vision_apim"):
+        return AzureOpenAI(
+            api_version=settings.get("azure_apim_vision_api_version"),
+            azure_endpoint=settings.get("azure_apim_vision_endpoint"),
+            api_key=settings.get("azure_apim_vision_subscription_key"),
+        )
+
+    if settings.get("azure_openai_vision_authentication_type") == "managed_identity":
+        token_provider = get_bearer_token_provider(
+            DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+        )
+        return AzureOpenAI(
+            api_version=settings.get("azure_openai_vision_api_version"),
+            azure_endpoint=settings.get("azure_openai_vision_endpoint"),
+            azure_ad_token_provider=token_provider,
+        )
+
     return AzureOpenAI(
-        azure_endpoint=os.environ["AZURE_OPENAI_VISION_ENDPOINT"],
-        api_key=os.environ["AZURE_OPENAI_VISION_API_KEY"],
-        api_version=os.getenv("AZURE_OPENAI_VISION_VERSION", "2024-02-15-preview"),
+        api_version=settings.get("azure_openai_vision_api_version"),
+        azure_endpoint=settings.get("azure_openai_vision_endpoint"),
+        api_key=settings.get("azure_openai_vision_key"),
     )
 
 def analyze_image(
@@ -33,11 +54,22 @@ def analyze_image(
     max_tokens: int = 512,
 ) -> str:
     
-    print("We're in analyze_image")
-    model_name = deployment or os.getenv("AZURE_OPENAI_VISION_DEPLOYMENT", "gpt-4o-mini-vision")
+    settings = get_settings()
+    model_name = deployment
+
+    if not model_name:
+        if settings.get("enable_vision_apim"):
+            model_name = settings.get("azure_apim_vision_deployment")
+        else:
+            vision_model_obj = settings.get("vision_model", {})
+            if vision_model_obj and vision_model_obj.get("selected"):
+                selected = vision_model_obj["selected"][0]
+                model_name = selected.get("deploymentName")
+        model_name = model_name or settings.get("azure_openai_vision_deployment")
+
     print(f"[Vision] using deployment: {model_name}")
     res = _client().chat.completions.create(
-        model=deployment or os.getenv("AZURE_OPENAI_VISION_DEPLOYMENT", "gpt-4o-mini"),
+        model=model_name,
         messages=[{
             "role": "user",
             "content": [

--- a/application/single_app/route_backend_models.py
+++ b/application/single_app/route_backend_models.py
@@ -68,6 +68,53 @@ def register_route_backend_models(app):
 
         return jsonify({"models": models})
 
+    @app.route('/api/models/vision', methods=['GET'])
+    @login_required
+    @user_required
+    def get_vision_models():
+        """Fetch GPT-4o vision deployments using Azure Mgmt library."""
+        settings = get_settings()
+
+        subscription_id = settings.get('azure_openai_vision_subscription_id', '')
+        resource_group = settings.get('azure_openai_vision_resource_group', '')
+        account_name = settings.get('azure_openai_vision_endpoint', '').split('.')[0].replace("https://", "")
+
+        if not subscription_id or not resource_group or not account_name:
+            return jsonify({"error": "Azure Vision Model subscription/RG/endpoint not configured"}), 400
+
+        if AZURE_ENVIRONMENT == "usgovernment":
+            credential = ClientSecretCredential(TENANT_ID, CLIENT_ID, MICROSOFT_PROVIDER_AUTHENTICATION_SECRET, authority=authority)
+            client = CognitiveServicesManagementClient(
+                credential=credential,
+                subscription_id=subscription_id,
+                base_url=resource_manager,
+                credential_scopes=credential_scopes
+            )
+        else:
+            credential = ClientSecretCredential(TENANT_ID, CLIENT_ID, MICROSOFT_PROVIDER_AUTHENTICATION_SECRET)
+            client = CognitiveServicesManagementClient(
+                credential=credential,
+                subscription_id=subscription_id
+            )
+
+        models = []
+        try:
+            deployments = client.deployments.list(
+                resource_group_name=resource_group,
+                account_name=account_name
+            )
+            for d in deployments:
+                model_name = d.properties.model.name
+                if model_name and ("gpt" in model_name.lower() or "vision" in model_name.lower()):
+                    models.append({
+                        "deploymentName": d.name,
+                        "modelName": model_name
+                    })
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+        return jsonify({"models": models})
+
 
     @app.route('/api/models/embedding', methods=['GET'])
     @login_required

--- a/application/single_app/route_backend_settings.py
+++ b/application/single_app/route_backend_settings.py
@@ -133,6 +133,9 @@ def register_route_backend_settings(app):
             elif test_type == 'image':
                 return _test_image_gen_connection(data)
 
+            elif test_type == 'vision':
+                return _test_vision_connection(data)
+
             elif test_type == 'safety':
                 return _test_safety_connection(data)
 
@@ -337,6 +340,64 @@ def _test_image_gen_connection(payload):
     except Exception as e:
         print(str(e))
         return jsonify({'error': f'Error generating model response: {str(e)}'}), 500
+
+
+def _test_vision_connection(payload):
+    """Attempt to connect to a vision-enabled GPT deployment."""
+    enable_apim = payload.get('enable_apim', False)
+    selected_model = payload.get('selected_model') or {}
+    img_b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z/CfAQADmQL/rPtONQAAAABJRU5ErkJggg=='
+
+    if enable_apim:
+        apim_data = payload.get('apim', {})
+        endpoint = apim_data.get('endpoint')
+        api_version = apim_data.get('api_version')
+        vision_model = apim_data.get('deployment')
+        subscription_key = apim_data.get('subscription_key')
+
+        vision_client = AzureOpenAI(
+            api_version=api_version,
+            azure_endpoint=endpoint,
+            api_key=subscription_key
+        )
+    else:
+        direct_data = payload.get('direct', {})
+        endpoint = direct_data.get('endpoint')
+        api_version = direct_data.get('api_version')
+        vision_model = selected_model.get('deploymentName')
+
+        if direct_data.get('auth_type') == 'managed_identity':
+            token_provider = get_bearer_token_provider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default")
+            vision_client = AzureOpenAI(
+                api_version=api_version,
+                azure_endpoint=endpoint,
+                azure_ad_token_provider=token_provider
+            )
+        else:
+            key = direct_data.get('key')
+            vision_client = AzureOpenAI(
+                api_version=api_version,
+                azure_endpoint=endpoint,
+                api_key=key
+            )
+
+    try:
+        response = vision_client.chat.completions.create(
+            model=vision_model,
+            messages=[{
+                'role': 'user',
+                'content': [
+                    {'type': 'text', 'text': 'test'},
+                    {'type': 'image_url', 'image_url': {'url': f'data:image/png;base64,{img_b64}'}}
+                ]
+            }],
+            max_tokens=5
+        )
+        if response:
+            return jsonify({'message': 'Vision connection successful'}), 200
+    except Exception as e:
+        print(str(e))
+        return jsonify({'error': f'Error testing vision: {str(e)}'}), 500
 
 
 def _test_safety_connection(payload):

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -189,6 +189,7 @@ def register_route_frontend_admin_settings(app):
             gpt_model_json = form_data.get('gpt_model_json', '')
             embedding_model_json = form_data.get('embedding_model_json', '')
             image_gen_model_json = form_data.get('image_gen_model_json', '')
+            vision_model_json = form_data.get('vision_model_json', '')
             try:
                 gpt_model_obj = json.loads(gpt_model_json) if gpt_model_json else {'selected': [], 'all': []}
             except Exception as e:
@@ -208,6 +209,12 @@ def register_route_frontend_admin_settings(app):
                 print(f"Error parsing image_gen_model_json: {e}")
                 flash('Error parsing Image Gen model data. Changes may not be saved.', 'warning')
                 image_gen_model_obj = settings.get('image_gen_model', {'selected': [], 'all': []}) # Fallback
+            try:
+                vision_model_obj = json.loads(vision_model_json) if vision_model_json else {'selected': [], 'all': []}
+            except Exception as e:
+                print(f"Error parsing vision_model_json: {e}")
+                flash('Error parsing Vision model data. Changes may not be saved.', 'warning')
+                vision_model_obj = settings.get('vision_model', {'selected': [], 'all': []}) # Fallback
 
             # --- Extract banner fields from form_data ---
             classification_banner_enabled = form_data.get('classification_banner_enabled') == 'on'
@@ -266,6 +273,20 @@ def register_route_frontend_admin_settings(app):
                 'azure_apim_image_gen_subscription_key': form_data.get('azure_apim_image_gen_subscription_key', '').strip(),
                 'azure_apim_image_gen_deployment': form_data.get('azure_apim_image_gen_deployment', '').strip(),
                 'azure_apim_image_gen_api_version': form_data.get('azure_apim_image_gen_api_version', '').strip(),
+
+                # Vision (Direct & APIM)
+                'enable_vision_apim': form_data.get('enable_vision_apim') == 'on',
+                'azure_openai_vision_endpoint': form_data.get('azure_openai_vision_endpoint', '').strip(),
+                'azure_openai_vision_api_version': form_data.get('azure_openai_vision_api_version', '').strip(),
+                'azure_openai_vision_authentication_type': form_data.get('azure_openai_vision_authentication_type', 'key'),
+                'azure_openai_vision_subscription_id': form_data.get('azure_openai_vision_subscription_id', '').strip(),
+                'azure_openai_vision_resource_group': form_data.get('azure_openai_vision_resource_group', '').strip(),
+                'azure_openai_vision_key': form_data.get('azure_openai_vision_key', '').strip(),
+                'vision_model': vision_model_obj,
+                'azure_apim_vision_endpoint': form_data.get('azure_apim_vision_endpoint', '').strip(),
+                'azure_apim_vision_subscription_key': form_data.get('azure_apim_vision_subscription_key', '').strip(),
+                'azure_apim_vision_deployment': form_data.get('azure_apim_vision_deployment', '').strip(),
+                'azure_apim_vision_api_version': form_data.get('azure_apim_vision_api_version', '').strip(),
 
                 # Workspaces
                 'enable_user_workspace': form_data.get('enable_user_workspace') == 'on',

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -9,6 +9,9 @@ let embeddingAll      = window.embeddingAll || [];
 let imageSelected = window.imageSelected || [];
 let imageAll      = window.imageAll || [];
 
+let visionSelected = window.visionSelected || [];
+let visionAll      = window.visionAll || [];
+
 let classificationCategories = window.classificationCategories || [];
 let enableDocumentClassification = window.enableDocumentClassification || false;
 
@@ -30,10 +33,12 @@ document.addEventListener('DOMContentLoaded', () => {
     renderGPTModels();
     renderEmbeddingModels();
     renderImageModels();
+    renderVisionModels();
 
     updateGptHiddenInput();
     updateEmbeddingHiddenInput();
     updateImageHiddenInput();
+    updateVisionHiddenInput();
 
     setupToggles(); // This function will be extended below
     
@@ -319,6 +324,75 @@ function updateImageHiddenInput() {
         all: imageAll
     };
     imgInput.value = JSON.stringify(payload);
+}
+
+function renderVisionModels() {
+    const listDiv = document.getElementById('vision_models_list');
+    if (!listDiv) return;
+
+    if (!visionAll || visionAll.length === 0) {
+        listDiv.innerHTML = '<p class="text-warning">No vision models found. Click "Fetch Vision Models" to populate.</p>';
+        return;
+    }
+
+    let html = '<ul class="list-group">';
+    visionAll.forEach(m => {
+        const isSelected = visionSelected.some(sel =>
+            sel.deploymentName === m.deploymentName && sel.modelName === m.modelName
+        );
+        const buttonLabel = isSelected ? 'Selected' : 'Select';
+        const buttonDisabled = isSelected ? 'disabled' : '';
+        html += `
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <span>${m.deploymentName} (Model: ${m.modelName})</span>
+                <button class="btn btn-sm btn-primary" ${buttonDisabled}
+                    onclick="selectVisionModel('${m.deploymentName}', '${m.modelName}')">
+                    ${buttonLabel}
+                </button>
+            </li>
+        `;
+    });
+    html += '</ul>';
+    listDiv.innerHTML = html;
+}
+
+const fetchVisionBtn = document.getElementById('fetch_vision_models_btn');
+if (fetchVisionBtn) {
+    fetchVisionBtn.addEventListener('click', async () => {
+        const listDiv = document.getElementById('vision_models_list');
+        listDiv.innerHTML = 'Fetching...';
+        try {
+            const resp = await fetch('/api/models/vision');
+            const data = await resp.json();
+            if (resp.ok && data.models && data.models.length > 0) {
+                visionAll = data.models;
+                renderVisionModels();
+                updateVisionHiddenInput();
+            } else {
+                listDiv.innerHTML = `<p class="text-danger">Error: ${data.error || 'No vision models found'}</p>`;
+            }
+        } catch (err) {
+            listDiv.innerHTML = `<p class="text-danger">Error fetching vision models: ${err.message}</p>`;
+        }
+    });
+}
+
+window.selectVisionModel = (deploymentName, modelName) => {
+    visionSelected = [{ deploymentName, modelName }];
+    document.getElementById('vision_model').value = deploymentName;
+    renderVisionModels();
+    updateVisionHiddenInput();
+    markFormAsModified();
+};
+
+function updateVisionHiddenInput() {
+    const input = document.getElementById('vision_model_json');
+    if (!input) return;
+    const payload = {
+        selected: visionSelected,
+        all: visionAll
+    };
+    input.value = JSON.stringify(payload);
 }
 
 // --- Helper to escape HTML for input values ---
@@ -718,6 +792,15 @@ function setupToggles() {
         });
     }
 
+    const enableVisionApim = document.getElementById('enable_vision_apim');
+    if (enableVisionApim) {
+        enableVisionApim.addEventListener('change', function () {
+            document.getElementById('non_apim_vision_settings').style.display = this.checked ? 'none' : 'block';
+            document.getElementById('apim_vision_settings').style.display = this.checked ? 'block' : 'none';
+            markFormAsModified();
+        });
+    }
+
     const enableEnhancedCitation = document.getElementById('enable_enhanced_citations');
     if (enableEnhancedCitation) {
         toggleEnhancedCitation(enableEnhancedCitation.checked);
@@ -802,6 +885,15 @@ function setupToggles() {
     if (imgAuthType) {
         imgAuthType.addEventListener('change', function () {
             document.getElementById('image_gen_key_container').style.display =
+                (this.value === 'key') ? 'block' : 'none';
+            markFormAsModified();
+        });
+    }
+
+    const visionAuthType = document.getElementById('azure_openai_vision_authentication_type');
+    if (visionAuthType) {
+        visionAuthType.addEventListener('change', function () {
+            document.getElementById('vision_key_container').style.display =
                 (this.value === 'key') ? 'block' : 'none';
             markFormAsModified();
         });
@@ -1016,6 +1108,56 @@ function setupTestButtons() {
                     resultDiv.innerHTML = `<span class="text-success">${data.message}</span>`;
                 } else {
                     resultDiv.innerHTML = `<span class="text-danger">${data.error || 'Error testing Image Gen'}</span>`;
+                }
+            } catch (err) {
+                resultDiv.innerHTML = `<span class="text-danger">Error: ${err.message}</span>`;
+            }
+        });
+    }
+
+    const testVisionBtn = document.getElementById('test_vision_button');
+    if (testVisionBtn) {
+        testVisionBtn.addEventListener('click', async () => {
+            const resultDiv = document.getElementById('test_vision_result');
+            resultDiv.innerHTML = 'Testing Vision...';
+
+            const enableApim = document.getElementById('enable_vision_apim').checked;
+
+            const payload = {
+                test_type: 'vision',
+                enable_apim: enableApim,
+                selected_model: visionSelected[0] || null
+            };
+
+            if (enableApim) {
+                payload.apim = {
+                    endpoint: document.getElementById('azure_apim_vision_endpoint').value,
+                    api_version: document.getElementById('azure_apim_vision_api_version').value,
+                    deployment: document.getElementById('azure_apim_vision_deployment').value,
+                    subscription_key: document.getElementById('azure_apim_vision_subscription_key').value
+                };
+            } else {
+                payload.direct = {
+                    endpoint: document.getElementById('azure_openai_vision_endpoint').value,
+                    auth_type: document.getElementById('azure_openai_vision_authentication_type').value,
+                    subscription_id: document.getElementById('azure_openai_vision_subscription_id').value,
+                    resource_group: document.getElementById('azure_openai_vision_resource_group').value,
+                    key: document.getElementById('azure_openai_vision_key').value,
+                    api_version: document.getElementById('azure_openai_vision_api_version').value
+                };
+            }
+
+            try {
+                const resp = await fetch('/api/admin/settings/test_connection', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                const data = await resp.json();
+                if (resp.ok) {
+                    resultDiv.innerHTML = `<span class="text-success">${data.message}</span>`;
+                } else {
+                    resultDiv.innerHTML = `<span class="text-danger">${data.error || 'Error testing Vision'}</span>`;
                 }
             } catch (err) {
                 resultDiv.innerHTML = `<span class="text-danger">Error: ${err.message}</span>`;
@@ -1381,6 +1523,8 @@ togglePassword('toggle_docintel_key', 'azure_document_intelligence_key');
 togglePassword('toggle_azure_apim_gpt_subscription_key', 'azure_apim_gpt_subscription_key');
 togglePassword('toggle_azure_apim_embedding_subscription_key', 'azure_apim_embedding_subscription_key');
 togglePassword('toggle_azure_apim_image_gen_subscription_key', 'azure_apim_image_gen_subscription_key');
+togglePassword('toggle_vision_key', 'azure_openai_vision_key');
+togglePassword('toggle_azure_apim_vision_subscription_key', 'azure_apim_vision_subscription_key');
 togglePassword('toggle_azure_apim_content_safety_subscription_key', 'azure_apim_content_safety_subscription_key');
 togglePassword('toggle_azure_apim_web_search_subscription_key', 'azure_apim_web_search_subscription_key');
 togglePassword('toggle_azure_apim_ai_search_subscription_key', 'azure_apim_ai_search_subscription_key');

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -428,6 +428,12 @@
                 </button>
             </li>
             <li class="nav-item" role="presentation">
+                <button class="nav-link" id="vision-tab" data-bs-toggle="tab" data-bs-target="#vision"
+                    type="button" role="tab" aria-controls="vision" aria-selected="false">
+                    Vision
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="workspaces-tab" data-bs-toggle="tab" data-bs-target="#workspaces" type="button"
                     role="tab" aria-controls="workspaces" aria-selected="false">
                     Workspaces
@@ -1004,6 +1010,108 @@
                     Test Image Connection
                 </button>
                 <div id="test_image_result" class="mt-2"></div>
+            </div>
+
+            <div class="tab-pane fade" id="vision" role="tabpanel" aria-labelledby="vision-tab">
+                <p class="text-muted">
+                    Configure settings for GPT-4o vision deployments.
+                </p>
+
+                <div class="form-group form-check form-switch mb-3 d-flex align-items-center">
+                    <input type="checkbox" class="form-check-input me-2" id="enable_vision_apim"
+                        name="enable_vision_apim" {% if settings.enable_vision_apim %}checked{% endif %}>
+                    <label class="form-check-label" for="enable_vision_apim">Use APIM instead of direct to Azure
+                        OpenAI endpoint.</label>
+                </div>
+
+                <div id="non_apim_vision_settings" {% if settings.enable_vision_apim %}style="display: none;" {% endif %}>
+                    <div class="card p-3 mb-3">
+                        <div class="mb-3">
+                            <label for="azure_openai_vision_endpoint" class="form-label">Azure OpenAI Vision Endpoint</label>
+                            <input type="text" class="form-control" id="azure_openai_vision_endpoint"
+                                name="azure_openai_vision_endpoint" value="{{ settings.azure_openai_vision_endpoint or '' }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="azure_openai_vision_authentication_type" class="form-label">Authentication Type</label>
+                            <select class="form-select" id="azure_openai_vision_authentication_type"
+                                name="azure_openai_vision_authentication_type">
+                                <option value="key" {% if settings.azure_openai_vision_authentication_type=='key' %}selected{% endif %}>Key</option>
+                                <option value="managed_identity" {% if settings.azure_openai_vision_authentication_type=='managed_identity' %}selected{% endif %}>Managed Identity</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="azure_openai_vision_subscription_id" class="form-label">Subscription ID</label>
+                            <input type="text" class="form-control" id="azure_openai_vision_subscription_id"
+                                name="azure_openai_vision_subscription_id" value="{{ settings.azure_openai_vision_subscription_id or '' }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="azure_openai_vision_resource_group" class="form-label">Resource Group</label>
+                            <input type="text" class="form-control" id="azure_openai_vision_resource_group"
+                                name="azure_openai_vision_resource_group" value="{{ settings.azure_openai_vision_resource_group or '' }}">
+                        </div>
+                        <div class="mb-3" id="vision_key_container" {% if settings.azure_openai_vision_authentication_type != 'key' %}style="display: none;" {% endif %}>
+                            <label for="azure_openai_vision_key" class="form-label">Azure OpenAI Vision Key</label>
+                            <div class="input-group">
+                                <input type="password" class="form-control" id="azure_openai_vision_key"
+                                    name="azure_openai_vision_key" value="{{ settings.azure_openai_vision_key or '' }}">
+                                <button type="button" class="btn btn-outline-secondary" id="toggle_vision_key">Show</button>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <div id="vision_models_list" class="mt-2 mb-3"></div>
+
+                            <input type="hidden" name="vision_model_json" id="vision_model_json" />
+                            <input type="hidden" id="vision_model" value="{{ settings.vision_model.selected[0].deploymentName if settings.vision_model.selected else '' }}" />
+
+                            <button type="button" class="btn btn-secondary" id="fetch_vision_models_btn">
+                                Fetch Vision Models
+                            </button>
+                        </div>
+                        <a href="#" class="fw-bold text-decoration-none mb-2" data-bs-toggle="collapse" data-bs-target="#advancedVisionFields" aria-expanded="false" aria-controls="advancedVisionFields">
+                            Show Advanced
+                        </a>
+                        <div class="collapse" id="advancedVisionFields">
+                            <div class="card card-body mt-2">
+                                <div class="mb-3">
+                                    <label for="azure_openai_vision_api_version" class="form-label">Azure OpenAI Vision API Version</label>
+                                    <input type="text" class="form-control" id="azure_openai_vision_api_version"
+                                        name="azure_openai_vision_api_version" value="{{ settings.azure_openai_vision_api_version or '' }}">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="apim_vision_settings" class="card p-3 mb-3" {% if not settings.enable_vision_apim %}style="display: none;" {% endif %}>
+                    <div class="mb-3">
+                        <label for="azure_apim_vision_endpoint" class="form-label">Azure APIM Endpoint</label>
+                        <input type="text" class="form-control" id="azure_apim_vision_endpoint"
+                            name="azure_apim_vision_endpoint" value="{{ settings.azure_apim_vision_endpoint or '' }}">
+                    </div>
+                    <div class="mb-3">
+                        <label for="azure_apim_vision_api_version" class="form-label">Azure APIM API Version</label>
+                        <input type="text" class="form-control" id="azure_apim_vision_api_version"
+                            name="azure_apim_vision_api_version" value="{{ settings.azure_apim_vision_api_version or '' }}">
+                    </div>
+                    <div class="mb-3">
+                        <label for="azure_apim_vision_deployment" class="form-label">Azure APIM Deployment</label>
+                        <input type="text" class="form-control" id="azure_apim_vision_deployment"
+                            name="azure_apim_vision_deployment" value="{{ settings.azure_apim_vision_deployment or '' }}">
+                    </div>
+                    <div class="mb-3">
+                        <label for="azure_apim_vision_subscription_key" class="form-label">Azure APIM Subscription Key</label>
+                        <div class="input-group">
+                            <input type="password" class="form-control" id="azure_apim_vision_subscription_key"
+                                name="azure_apim_vision_subscription_key" value="{{ settings.azure_apim_vision_subscription_key or '' }}">
+                            <button type="button" class="btn btn-outline-secondary" id="toggle_azure_apim_vision_subscription_key">Show</button>
+                        </div>
+                    </div>
+                </div>
+
+                <button type="button" class="btn btn-secondary mt-3" id="test_vision_button">
+                    Test Vision Connection
+                </button>
+                <div id="test_vision_result" class="mt-2"></div>
             </div>
 
             
@@ -2164,6 +2272,9 @@
 
     window.imageSelected = JSON.parse('{{ settings.image_gen_model.selected|tojson()|safe }}' || '[]');
     window.imageAll      = JSON.parse('{{ settings.image_gen_model.all|tojson()|safe }}' || '[]');
+
+    window.visionSelected = JSON.parse('{{ settings.vision_model.selected|tojson()|safe }}' || '[]');
+    window.visionAll      = JSON.parse('{{ settings.vision_model.all|tojson()|safe }}' || '[]');
 
     // *** NEW: Classification Data ***
     try {


### PR DESCRIPTION
## Summary
- add `/api/models/vision` route
- extend admin settings to configure GPT-4o vision
- implement test connection logic for vision
- wire up vision model fetching in the admin UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840a988b80883298cdd29952cadace2